### PR TITLE
dom: Added function to load SVG document from std::string

### DIFF
--- a/src/svgdom/dom.cpp
+++ b/src/svgdom/dom.cpp
@@ -2966,6 +2966,14 @@ std::unique_ptr<SvgElement> svgdom::load(std::istream& s){
 	return ::load(doc);
 }
 
+std::unique_ptr<SvgElement> svgdom::load(std::string& s){
+	pugi::xml_document doc;
+
+	doc.load_string(s.c_str());
+
+	return ::load(doc);
+}
+
 real SvgElement::aspectRatio(real dpi)const{
 	real w = this->width.toPx(dpi);
 	real h = this->height.toPx(dpi);

--- a/src/svgdom/dom.hpp
+++ b/src/svgdom/dom.hpp
@@ -633,10 +633,16 @@ std::unique_ptr<SvgElement> load(const papki::File& f);
  * @param s - input stream to load SVG from.
  * @return unique pointer to the root of SVG document tree.
  */
-
 std::unique_ptr<SvgElement> load(std::istream& s);
 
-}//~namespace
+/**
+ * @brief Load SVG document.
+ * Load SVG document from std::string.
+ * @param s - input string to load SVG from.
+ * @return unique pointer to the root of SVG document tree.
+ */
+std::unique_ptr<SvgElement> load(std::string& s);
 
+}//~namespace
 
 std::ostream& operator<<(std::ostream& s, const svgdom::Length& l);


### PR DESCRIPTION
Added function `load(std::string& s)` in order to load SVG doms from an `std::string`.