### PR TITLE
Added CustomStringElement to insert custom strings when generating XML

### DIFF
--- a/src/svgdom/StreamWriter.cpp
+++ b/src/svgdom/StreamWriter.cpp
@@ -207,7 +207,9 @@ void StreamWriter::visit(const SymbolElement& e) {
 void StreamWriter::visit(const CustomStringElement& e) {
   auto ind = indentStr(this->indent);
   
-  s << ind;
-  s << e.getCustomString();
-  s << std::endl;
+	if (!e.getCustomString().empty()) {
+	  s << ind;
+	  s << e.getCustomString();
+	  s << std::endl;
+	}
 }

--- a/src/svgdom/StreamWriter.cpp
+++ b/src/svgdom/StreamWriter.cpp
@@ -203,3 +203,11 @@ void StreamWriter::visit(const SymbolElement& e) {
 	}
 	s << std::endl;
 }
+
+void StreamWriter::visit(const CustomStringElement& e) {
+  auto ind = indentStr(this->indent);
+  
+  s << ind;
+  s << e.getCustomString();
+  s << std::endl;
+}

--- a/src/svgdom/StreamWriter.hxx
+++ b/src/svgdom/StreamWriter.hxx
@@ -29,6 +29,7 @@ public:
 	void visit(const EllipseElement& e) override;
 	void visit(const RectElement& e) override;
 	void visit(const LineElement& e) override;
+	void visit(const CustomStringElement& e) override;
 };
 
 }

--- a/src/svgdom/Visitor.cpp
+++ b/src/svgdom/Visitor.cpp
@@ -62,3 +62,7 @@ void Visitor::visit(const LinearGradientElement& e) {
 void Visitor::visit(const RadialGradientElement& e) {
 	this->defaultVisit(e);
 }
+
+void Visitor::visit(const CustomStringElement& e) {
+	this->defaultVisit(e);
+}

--- a/src/svgdom/Visitor.hpp
+++ b/src/svgdom/Visitor.hpp
@@ -3,6 +3,7 @@
 #include "elements/Structurals.hpp"
 #include "elements/Shapes.hpp"
 #include "elements/Gradients.hpp"
+#include "elements/Custom.hpp"
 
 namespace svgdom{
 /**
@@ -30,6 +31,7 @@ public:
 	virtual void visit(const Gradient::StopElement& e);
 	virtual void visit(const LinearGradientElement& e);
 	virtual void visit(const RadialGradientElement& e);
+	virtual void visit(const CustomStringElement& e);
 	
 	/**
 	 * @brief Default visit method.

--- a/src/svgdom/elements/Custom.cpp
+++ b/src/svgdom/elements/Custom.cpp
@@ -11,6 +11,10 @@
 
 using namespace svgdom;
 
+CustomStringElement::CustomStringElement() {}
+
+CustomStringElement::CustomStringElement(std::string s) : customString(s) {}
+
 std::string CustomStringElement::getCustomString() const {
   return customString;
 }

--- a/src/svgdom/elements/Custom.cpp
+++ b/src/svgdom/elements/Custom.cpp
@@ -26,6 +26,3 @@ void CustomStringElement::setCustomString(std::string s) {
 void CustomStringElement::accept(Visitor& visitor) const {
   visitor.visit(*this);
 }
-
-void CustomStringElement::attribsToStream(std::ostream& s) const {
-}

--- a/src/svgdom/elements/Custom.cpp
+++ b/src/svgdom/elements/Custom.cpp
@@ -1,0 +1,27 @@
+#include "Custom.hpp"
+
+#include "../util.hxx"
+#include "../Visitor.hpp"
+
+#include <sstream>
+#include <cctype>
+
+#include <utki/debug.hpp>
+
+
+using namespace svgdom;
+
+std::string CustomStringElement::getCustomString() const {
+  return customString;
+}
+
+void CustomStringElement::setCustomString(std::string s) {
+  customString = s;
+}
+
+void CustomStringElement::accept(Visitor& visitor) const {
+  visitor.visit(*this);
+}
+
+void CustomStringElement::attribsToStream(std::ostream& s) const {
+}

--- a/src/svgdom/elements/Custom.hpp
+++ b/src/svgdom/elements/Custom.hpp
@@ -20,8 +20,6 @@ struct CustomStringElement : public Element
   
   void setCustomString(std::string s);
   
-	void attribsToStream(std::ostream& s)const;
-  
   void accept(Visitor& visitor) const override;
 };
 

--- a/src/svgdom/elements/Custom.hpp
+++ b/src/svgdom/elements/Custom.hpp
@@ -12,6 +12,10 @@ struct CustomStringElement : public Element
 {
   std::string customString;
   
+	CustomStringElement();
+	
+	CustomStringElement(std::string s);
+	
   std::string getCustomString() const;
   
   void setCustomString(std::string s);

--- a/src/svgdom/elements/Custom.hpp
+++ b/src/svgdom/elements/Custom.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include "Element.hpp"
+
+namespace svgdom{
+
+/**
+ * @brief Element representing a custom string to insert in XML.
+ */
+struct CustomStringElement : public Element
+{
+  std::string customString;
+  
+  std::string getCustomString() const;
+  
+  void setCustomString(std::string s);
+  
+	void attribsToStream(std::ostream& s)const;
+  
+  void accept(Visitor& visitor) const override;
+};
+
+
+}


### PR DESCRIPTION
Added simple element called `CustomStringElement` and corresponding Visitor functions to inject custom strings to the svg's XML.