### PR TITLE
StreamWriter: Moved s, indentStr(), and indent from private to protected

### DIFF
--- a/src/svgdom/StreamWriter.hpp
+++ b/src/svgdom/StreamWriter.hpp
@@ -11,9 +11,10 @@ private:
 	std::string name;
 	std::vector<std::pair<std::string, std::string>> attributes;
 protected:
+	// s, indent, and indentStr() are protected to allow classes that inherit StreamWriter to write to stream s (eg: for custom StreamWriter and custom Element)
 	std::ostream& s;
-	std::string indentStr();
 	unsigned indent = 0;
+	std::string indentStr();
 	
 	void setName(const std::string& name);
 	void addAttribute(const std::string& name, const std::string& value);

--- a/src/svgdom/StreamWriter.hpp
+++ b/src/svgdom/StreamWriter.hpp
@@ -11,7 +11,7 @@ private:
 	std::string name;
 	std::vector<std::pair<std::string, std::string>> attributes;
 protected:
-	// s, indent, and indentStr() are protected to allow classes that inherit StreamWriter to write to stream s (eg: for custom StreamWriter and custom Element)
+	// s, indent, and indentStr() are made protected to allow writing arbitrary content to stream for those who extend the class, as this was needed in some projects.
 	std::ostream& s;
 	unsigned indent = 0;
 	std::string indentStr();

--- a/src/svgdom/StreamWriter.hpp
+++ b/src/svgdom/StreamWriter.hpp
@@ -6,17 +6,15 @@ namespace svgdom{
 
 class StreamWriter : public Visitor{
 private:
-	std::ostream& s;
-	
-	std::string indentStr();
-	
-	unsigned indent = 0;
-	
 	void childrenToStream(const Container& e);
 	
 	std::string name;
 	std::vector<std::pair<std::string, std::string>> attributes;
 protected:
+	std::ostream& s;
+	std::string indentStr();
+	unsigned indent = 0;
+	
 	void setName(const std::string& name);
 	void addAttribute(const std::string& name, const std::string& value);
 	void addAttribute(const std::string& name, const Length& value);


### PR DESCRIPTION
On `StreamWriter` moved `s`, `indentStr()`, and `indent` members from `private` to `protected` in order to allow custom elements to write string directly to the stream (and also add indents). See issue #9 