### PR TITLE
ConstVisitor: Container Elements are calling relayAccept() by default

### DIFF
--- a/src/svgdom/Visitor.cpp
+++ b/src/svgdom/Visitor.cpp
@@ -117,22 +117,27 @@ void ConstVisitor::visit(const PolygonElement& e) {
 
 void ConstVisitor::visit(const GElement& e) {
 	this->defaultVisit(e);
+	this->relayAccept(e);
 }
 
 void ConstVisitor::visit(const SvgElement& e) {
 	this->defaultVisit(e);
+	this->relayAccept(e);
 }
 
 void ConstVisitor::visit(const SymbolElement& e) {
 	this->defaultVisit(e);
+	this->relayAccept(e);
 }
 
 void ConstVisitor::visit(const UseElement& e) {
 	this->defaultVisit(e);
+	
 }
 
 void ConstVisitor::visit(const DefsElement& e) {
 	this->defaultVisit(e);
+	this->relayAccept(e);
 }
 
 void ConstVisitor::visit(const Gradient::StopElement& e) {
@@ -141,14 +146,17 @@ void ConstVisitor::visit(const Gradient::StopElement& e) {
 
 void ConstVisitor::visit(const LinearGradientElement& e) {
 	this->defaultVisit(e);
+	this->relayAccept(e);
 }
 
 void ConstVisitor::visit(const RadialGradientElement& e) {
 	this->defaultVisit(e);
+	this->relayAccept(e);
 }
 
 void ConstVisitor::visit(const FilterElement& e){
 	this->defaultVisit(e);
+	this->relayAccept(e);
 }
 
 void ConstVisitor::visit(const FeGaussianBlurElement& e){


### PR DESCRIPTION
Container elements of `ConstVisitor` are now calling relayAccept() by default.

This would be useful in cases where we want to call only the default visitor (like printing the ID for all elements). Before this commit, calling the default visitor for each element would require to override the default visitor and all the Container visitors, since we have to relayAccept all the children of the containers. Now, we only have to override the default visitor.